### PR TITLE
Send metadata updates from streams (E.g. internet radio)

### DIFF
--- a/src/controlserver.cpp
+++ b/src/controlserver.cpp
@@ -31,7 +31,7 @@
 
 #include "debug.h"
 
-pfc::string8 const controlserver::m_versionNumber = "1.1.5";
+pfc::string8 const controlserver::m_versionNumber = "1.1.6";
 std::vector<SOCKET> controlserver::m_vclientSockets;
 std::vector<bool> controlserver::m_canSends;
 HANDLE controlserver::m_WSAendEvent = NULL;

--- a/src/controlserver_resources.rc
+++ b/src/controlserver_resources.rc
@@ -77,7 +77,7 @@ BEGIN
     GROUPBOX        "GENERAL OPTIONS : ",IDC_STATIC,7,199,266,31
     CONTROL         "Prevent clients from closing Foobar2000",IDC_PREVENTCLOSE,
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,21,212,142,10
-    LTEXT           "Version : 1.1.5",IDC_STATIC_VERSION,14,265,81,9,SS_CENTERIMAGE
+    LTEXT           "Version : 1.1.6",IDC_STATIC_VERSION,14,265,81,9,SS_CENTERIMAGE
 END
 
 

--- a/src/foo_controlserver.vcxproj
+++ b/src/foo_controlserver.vcxproj
@@ -51,7 +51,7 @@
     <OutDir>.\Debug\</OutDir>
     <IntDir>.\Debug\</IntDir>
     <LinkIncremental>true</LinkIncremental>
-    <IncludePath>..//include;$(IncludePath)</IncludePath>
+    <IncludePath>..//..//..;../../;..//include;$(IncludePath)</IncludePath>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <Midl>
@@ -75,13 +75,14 @@
       <ProgramDataBaseFileName>.\Release/</ProgramDataBaseFileName>
       <WarningLevel>Level3</WarningLevel>
       <SuppressStartupBanner>true</SuppressStartupBanner>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <Culture>0x0409</Culture>
     </ResourceCompile>
     <Link>
-      <AdditionalDependencies>ws2_32.lib;odbc32.lib;odbccp32.lib;shlwapi.lib;../../shared/shared.lib;../../../pfc/Release/pfc.lib;../../SDK/Release/foobar2000_SDK.lib;../../foobar2000_component_client/Release/foobar2000_component_client.lib;../../helpers\Release\foobar2000_sdk_helpers.lib;../../ATLHelpers\Release\foobar2000_ATL_helpers.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>ws2_32.lib;odbc32.lib;odbccp32.lib;shlwapi.lib;../../shared/shared.lib;../../../pfc/Release/pfc.lib;../../SDK/Release/foobar2000_SDK.lib;../../foobar2000_component_client/Release/foobar2000_component_client.lib;../../helpers\Release\foobar2000_sdk_helpers.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>.\Release/foo_controlserver.dll</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <ProgramDatabaseFile>.\Release/foo_controlserver.pdb</ProgramDatabaseFile>
@@ -120,6 +121,7 @@
       <WarningLevel>Level3</WarningLevel>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>


### PR DESCRIPTION
Does what it says on the tin!

Closes #3. Turns out it was easy enough.

Bumps the version to 1.1.6.